### PR TITLE
Add Gradual Warp effect

### DIFF
--- a/au3/plug-ins/CMakeLists.txt
+++ b/au3/plug-ins/CMakeLists.txt
@@ -33,6 +33,7 @@ set( SOURCES
    sample-data-export.ny
    sample-data-import.ny
    spectral-delete.ny
+   gradual-warp.ny
    tremolo.ny
    vocoder.ny
 )

--- a/au3/plug-ins/gradual-warp.ny
+++ b/au3/plug-ins/gradual-warp.ny
@@ -1,0 +1,14 @@
+$nyquist plug-in
+$version 4
+$type process
+$name "Gradual Warp"
+$control LENGTH "Output Length (%)" float-text "" 150 100 400
+$control DROP "Drop volume near end" choice (("No" 0) ("Yes" 1)) 0
+
+(setq ratio (/ LENGTH 100.0))
+(setq dur (get-duration 1))
+(setq stretchfn (pwlv 1 0 dur ratio))
+(setq result (pv-time-pitch *track* stretchfn stretchfn dur))
+(if (= DROP 1)
+    (setf result (mult result (pwlv 1 (* dur 0.8) 0 dur 0))))
+result


### PR DESCRIPTION
## Summary
- add a `gradual-warp.ny` Nyquist plug‑in that gradually slows audio and optionally fades volume
- install the new plug‑in via the plug‑in CMake configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b2e0d0a34832f9ab554dcfc176c0f